### PR TITLE
fix(filing): 企业备案「重新编辑信息」按钮被 el-form disabled 级联置灰

### DIFF
--- a/frontend/src/views/enterprise/Filing.vue
+++ b/frontend/src/views/enterprise/Filing.vue
@@ -82,15 +82,17 @@
           </el-form-item>
         </el-col>
       </el-row>
-
-      <div v-if="!readonly" class="actions">
-        <el-button :loading="saving" @click="onSave">保存草稿</el-button>
-        <el-button type="primary" :loading="submitting" @click="onSubmit">{{ submitLabel }}</el-button>
-      </div>
-      <div v-else class="actions">
-        <el-button v-if="data?.filingStatus === 'APPROVED'" type="primary" @click="readonly = false">重新编辑信息</el-button>
-      </div>
     </el-form>
+
+    <!-- Actions placed OUTSIDE <el-form> so they don't inherit its disabled state
+         (Element Plus cascades the form's `disabled` to nested buttons). -->
+    <div v-if="!readonly" class="actions">
+      <el-button :loading="saving" @click="onSave">保存草稿</el-button>
+      <el-button type="primary" :loading="submitting" @click="onSubmit">{{ submitLabel }}</el-button>
+    </div>
+    <div v-else class="actions">
+      <el-button v-if="data?.filingStatus === 'APPROVED'" type="primary" @click="readonly = false">重新编辑信息</el-button>
+    </div>
   </el-card>
 </template>
 


### PR DESCRIPTION
把两组 action 按钮从 <el-form> 内移到外部，避免 Element Plus 的
form disabled 状态级联到按钮。APPROVED/PENDING 只读状态下按钮
现在可正常点击。